### PR TITLE
Refactoring of the `MinimaxSearcher` class

### DIFF
--- a/Checkers/Checkers.csproj
+++ b/Checkers/Checkers.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Services\JumpSequenceExplorer.cs" />
     <Compile Include="Services\MediumStrategy.cs" />
     <Compile Include="Services\MinimaxSearcher.cs" />
+    <Compile Include="Services\MoveApplier.cs" />
     <Compile Include="Services\ProStrategy.cs" />
     <Compile Include="Services\RandomProvider.cs" />
     <Compile Include="Views\GameOverForm.cs">

--- a/Checkers/Models/Game.cs
+++ b/Checkers/Models/Game.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+
 
 namespace Checkers.Models
 {

--- a/Checkers/Models/Move.cs
+++ b/Checkers/Models/Move.cs
@@ -2,10 +2,18 @@
 {
     public class Move
     {
-        public Piece Piece { get; }
-        public int ToRow { get; }
-        public int ToCol { get; }
-        public Piece CapturedPiece { get; }
+        public Piece Piece { get; set; }
+        public int ToRow { get; set; }
+        public int ToCol { get; set; }
+        public Piece CapturedPiece { get; set; }
+
+        // Властивості-координати
+        public int PieceRow => Piece?.Row ?? -1;
+        public int PieceCol => Piece?.Col ?? -1;
+        public int CapturedPieceRow => CapturedPiece?.Row ?? -1;
+        public int CapturedPieceCol => CapturedPiece?.Col ?? -1;
+
+        public Move() { }
 
         public Move(Piece piece, int toRow, int toCol, Piece capturedPiece = null)
         {

--- a/Checkers/Program.cs
+++ b/Checkers/Program.cs
@@ -41,6 +41,8 @@ namespace Checkers
                 };
                 return new AIService(dict, sp.GetRequiredService<JumpSequenceExplorer>());
             });
+            services.AddTransient<MoveApplier>();
+            services.AddTransient<MinimaxSearcher>();
 
             // Game services
             services.AddSingleton<GameSaver>();

--- a/Checkers/Services/GameSaver.cs
+++ b/Checkers/Services/GameSaver.cs
@@ -1,0 +1,96 @@
+﻿using Checkers.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows.Forms;
+using System.Xml;
+using Formatting = Newtonsoft.Json.Formatting;
+
+namespace Checkers.Services
+{
+    public class GameSaver
+    {
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.Auto,
+            Formatting = Formatting.Indented,
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+        };
+
+        public bool Save(Game game, string filePath)
+        {
+            try
+            {
+                var state = new GameState
+                {
+                    Board = game.Board,
+                    CurrentPlayer = game.CurrentPlayer,
+                    SelectedPiece = game.SelectedPiece,
+                    ValidMoves = game.ValidMoves,
+                    IsGameOver = game.IsGameOver,
+                    Winner = game.Winner
+                };
+
+
+
+                string json = JsonConvert.SerializeObject(state, _settings);
+                File.WriteAllText(filePath, json);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Помилка збереження: {ex.Message}", "Помилка",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        public Game Load(string filePath)
+        {
+            try
+            {
+                if (!File.Exists(filePath))
+                {
+                    MessageBox.Show("Файл не знайдено", "Помилка",
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return null;
+                }
+
+                string json = File.ReadAllText(filePath);
+                var state = JsonConvert.DeserializeObject<GameState>(json, _settings);
+
+                var game = new Game
+                {
+                    Board = state.Board,
+                    CurrentPlayer = state.CurrentPlayer,
+                    IsGameOver = state.IsGameOver,
+                    Winner = state.Winner
+                };
+
+                if (state.SelectedPiece != null)
+                {
+                    game.SelectedPiece = game.Board.GetPiece(
+                        state.SelectedPiece.Row,
+                        state.SelectedPiece.Col);
+                }
+
+                game.ValidMoves = state.ValidMoves.ConvertAll(mi =>
+                    new Move(
+                        game.Board.GetPiece(mi.PieceRow, mi.PieceCol),
+                        mi.ToRow,
+                        mi.ToCol,
+                        mi.CapturedPieceRow >= 0 ?
+                            game.Board.GetPiece(mi.CapturedPieceRow, mi.CapturedPieceCol) : null));
+
+                return game;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Помилка завантаження: {ex.Message}", "Помилка",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return null;
+            }
+        }
+    }
+}

--- a/Checkers/Services/MinimaxSearcher.cs
+++ b/Checkers/Services/MinimaxSearcher.cs
@@ -10,23 +10,23 @@ namespace Checkers.Services
     public class MinimaxSearcher
     {
         private readonly IBoardEvaluator _evaluator;
+        private readonly MoveApplier _moveApplier;
 
-        public MinimaxSearcher(IBoardEvaluator evaluator)
+        public MinimaxSearcher(IBoardEvaluator evaluator, MoveApplier moveApplier)
         {
             _evaluator = evaluator;
+            _moveApplier = moveApplier;
         }
 
         public Move FindBestMove(Board board, PlayerType player, List<Move> moves, int depth)
         {
             Move best = null;
             int bestScore = int.MinValue;
+
             foreach (var m in moves)
             {
                 var b2 = board.Clone();
-                var p = b2.GetPiece(m.Piece.Row, m.Piece.Col);
-                var cap = m.CapturedPiece != null ? b2.GetPiece(m.CapturedPiece.Row, m.CapturedPiece.Col) : null;
-                b2.MovePiece(p, m.ToRow, m.ToCol);
-                if (cap != null) b2.RemovePiece(cap.Row, cap.Col);
+                _moveApplier.Apply(b2, m);
 
                 int score = Minimax(b2, depth - 1, int.MinValue, int.MaxValue, player != PlayerType.Black);
                 if (score > bestScore)
@@ -35,6 +35,7 @@ namespace Checkers.Services
                     best = m;
                 }
             }
+
             return best;
         }
 
@@ -53,7 +54,7 @@ namespace Checkers.Services
                 foreach (var m in moves)
                 {
                     var b2 = board.Clone();
-                    ApplyMove(b2, m);
+                    _moveApplier.Apply(b2, m);
                     value = Math.Max(value, Minimax(b2, depth - 1, alpha, beta, false));
                     alpha = Math.Max(alpha, value);
                     if (alpha >= beta) break;
@@ -65,12 +66,13 @@ namespace Checkers.Services
                 foreach (var m in moves)
                 {
                     var b2 = board.Clone();
-                    ApplyMove(b2, m);
+                    _moveApplier.Apply(b2, m);
                     value = Math.Min(value, Minimax(b2, depth - 1, alpha, beta, true));
                     beta = Math.Min(beta, value);
                     if (beta <= alpha) break;
                 }
             }
+
             return value;
         }
 
@@ -86,14 +88,6 @@ namespace Checkers.Services
                 }
             var caps = all.Where(m => m.CapturedPiece != null).ToList();
             return caps.Any() ? caps : all;
-        }
-
-        private void ApplyMove(Board board, Move m)
-        {
-            var p = board.GetPiece(m.Piece.Row, m.Piece.Col);
-            var cap = m.CapturedPiece != null ? board.GetPiece(m.CapturedPiece.Row, m.CapturedPiece.Col) : null;
-            board.MovePiece(p, m.ToRow, m.ToCol);
-            if (cap != null) board.RemovePiece(cap.Row, cap.Col);
         }
     }
 }

--- a/Checkers/Services/MoveApplier.cs
+++ b/Checkers/Services/MoveApplier.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Checkers.Models;
+
+namespace Checkers.Services
+{
+    public class MoveApplier
+    {
+        public void Apply(Board board, Move move)
+        {
+            var piece = board.GetPiece(move.Piece.Row, move.Piece.Col);
+            var captured = move.CapturedPiece != null ? board.GetPiece(move.CapturedPiece.Row, move.CapturedPiece.Col) : null;
+
+            board.MovePiece(piece, move.ToRow, move.ToCol);
+            if (captured != null)
+                board.RemovePiece(captured.Row, captured.Col);
+        }
+    }
+}
+


### PR DESCRIPTION
### ✅ What's done

🔧 **Refactoring of the `MinimaxSearcher` class** was carried out taking into account the SOLID principles.

* The logic of applying a move into a separate `MoveApplier` service was allocated.

* The `ApplyMove` method was moved to `MoveApplier`.

* `MoveApplier` injection was added to `MinimaxSearcher` via the constructor.

* `MoveApplier` was registered in the DI container for correct dependency operation.

### 🎯 Why is this needed?

The `MinimaxSearcher` class violated the **Single Responsibility Principle (SRP)** because:

* it dealt with both move selection,
* and the logic of changing the board state (`ApplyMove`),
* and the generation of possible moves (`GetMoves`).

Refactoring allowed these responsibilities to be divided.

### 🧠 What this improves

* ✅ **Cleaner and easier to test** code — now the logic of board changes can be tested separately in `MoveApplier`.
* ✅ **Easier to maintain and extend** — for example, you can easily implement a different type of move application (e.g. with logging or validation).
* ✅ **SRP and DIP compliance** (Single Responsibility & Dependency Inversion Principles).
* ✅ **Better readability and code reuse**.

### 🧪 Note

> Also updated the DI container to avoid the `System.InvalidOperationException` error when creating `MinimaxSearcher`.