### PR TITLE
Покращено читабельність та розділення відповідальностей

### DIFF
--- a/Checkers/Checkers.csproj
+++ b/Checkers/Checkers.csproj
@@ -64,6 +64,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\GameCommandInvoker.cs" />
+    <Compile Include="Commands\IGameCommand.cs" />
+    <Compile Include="Commands\LoadGameCommand.cs" />
+    <Compile Include="Commands\SaveGameCommand.cs" />
     <Compile Include="Controllers\GameController.cs" />
     <Compile Include="Controllers\TournamentManager.cs" />
     <Compile Include="Models\Board.cs" />
@@ -90,6 +94,9 @@
     <Compile Include="Services\MoveApplier.cs" />
     <Compile Include="Services\ProStrategy.cs" />
     <Compile Include="Services\RandomProvider.cs" />
+    <Compile Include="Strategies\IGameSessionStrategy.cs" />
+    <Compile Include="Strategies\RegularGameStrategy.cs" />
+    <Compile Include="Strategies\TournamentGameStrategy.cs" />
     <Compile Include="Views\GameOverForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Checkers/Services/BasicBoardEvaluator.cs
+++ b/Checkers/Services/BasicBoardEvaluator.cs
@@ -29,22 +29,27 @@ namespace Checkers.Services
                     var piece = board.GetPiece(r, c);
                     if (piece == null) continue;
 
-                    int value = GetPieceValue(piece);
-                    bool isCentral = IsCentralPosition(r, c);
-                    bool isEdge = IsEdgePosition(r, c);
-                    bool isVulnerable = IsVulnerable(board, piece);
-
-                    int total = value
-                                + (isCentral ? CentralBonus : 0)
-                                + (isEdge ? EdgePenalty : 0)
-                                + (isVulnerable ? VulnerablePenalty : 0);
-
-                    score += piece.Player == maximizingPlayer ? total : -total;
+                    score += EvaluatePiece(board, piece, maximizingPlayer);
                 }
             }
 
             return score;
         }
+
+        private int EvaluatePiece(Board board, Piece piece, PlayerType maximizingPlayer)
+        {
+			int value = GetPieceValue(piece);
+			bool isCentral = IsCentralPosition(piece.Row, piece.Col);
+			bool isEdge = IsEdgePosition(piece.Row, piece.Col);
+			bool isVulnerable = IsVulnerable(board, piece);
+
+			int total = value
+						+ (isCentral ? CentralBonus : 0)
+						+ (isEdge ? EdgePenalty : 0)
+						+ (isVulnerable ? VulnerablePenalty : 0);
+
+			return piece.Player == maximizingPlayer ? total : -total;
+		}
 
         private int GetPieceValue(Piece piece)
         {
@@ -62,22 +67,24 @@ namespace Checkers.Services
             return row == 0 || row == BoardSize - 1 || col == 0 || col == BoardSize - 1;
         }
 
-        private bool IsVulnerable(Board board, Piece piece)
-        {
-            PlayerType opponent = piece.Player == PlayerType.White ? PlayerType.Black : PlayerType.White;
-            var opponentMoves = new List<Move>();
+		private bool IsVulnerable(Board board, Piece piece)
+		{
+			PlayerType opponent = piece.Player == PlayerType.White ? PlayerType.Black : PlayerType.White;
 
-            for (int r = 0; r < BoardSize; r++)
-            {
-                for (int c = 0; c < BoardSize; c++)
-                {
-                    var p = board.GetPiece(r, c);
-                    if (p?.Player == opponent)
-                        opponentMoves.AddRange(board.GetValidMoves(p));
-                }
-            }
+			for (int r = 0; r < BoardSize; r++)
+			{
+				for (int c = 0; c < BoardSize; c++)
+				{
+					var p = board.GetPiece(r, c);
+					if (p?.Player != opponent) continue;
 
-            return opponentMoves.Any(m => m.CapturedPiece?.Row == piece.Row && m.CapturedPiece?.Col == piece.Col);
-        }
-    }
+					var opponentMoves = board.GetValidMoves(p);
+					if (opponentMoves.Any(m => m.CapturedPiece?.Row == piece.Row && m.CapturedPiece?.Col == piece.Col))
+						return true;
+				}
+			}
+
+			return false;
+		}
+	}
 }


### PR DESCRIPTION
## Проблема

Метод `Evaluate` у класі `BasicBoardEvaluator` мав занадто багато відповідальностей: він не тільки перебирає фігури на дошці, але й обчислює їхню індивідуальну оцінку, перевіряє центральність, положення на краю та вразливість. Це ускладнювало читання коду та унеможливлювало повторне використання логіки оцінки однієї фігури.

## Зміни

- Винесено логіку оцінки окремої фігури в окремий метод `EvaluatePiece`.
- Метод `IsVulnerable` оптимізовано: тепер він зупиняється після першого знайденого загрозливого ходу.
- Покращено читабельність та розділення відповідальностей у класі.

## Результат

- Код став більш читабельним та підтримуваним.
- Зменшено навантаження на метод `Evaluate`.
- Створені умови для потенційного розширення логіки оцінки фігур без зміни основного методу.
